### PR TITLE
ci: require tests to pass before uploading to pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
   # Upload to PyPI
   upload_pypi:
     name: Publish to PyPI
-    needs: [build_wheels, build_in_manylinux2010, build_arch_wheels]
+    needs: [run_test, build_wheels, build_in_manylinux2010, build_arch_wheels]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
previously, even if the test job fails, the wheels will be still be built and added to pypi
ensure that the tests are required to pass to upload anything to pypi