### PR TITLE
Use python_requires to indicate Python version support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Topic :: Text Processing',
         'Topic :: Text Processing :: General',
     ],
+    python_requires='>=3.6',
 
     package_dir={'regex': 'regex_3'},
     py_modules=['regex.__init__', 'regex.regex', 'regex._regex_core',


### PR DESCRIPTION
I have an old Python 2.7 project that depends on regex and it was trying to install 2022.1.18, even though Python 2.7 support was [removed from the classifiers in 2021.4.4](https://github.com/mrabarnett/mrab-regex/commit/1e6986b92f978087eb34ca79732d3b0c45be8652#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L15).