### PR TITLE
Stop supporting Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   PYTHON_VER: '3.10'  # Python to run test/cibuildwheel
-  CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
+  CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
   CIBW_TEST_COMMAND: python -m unittest regex.test_regex
 
 jobs:
@@ -85,7 +85,7 @@ jobs:
       # manylinux2014  >=19.3   3.7.8+, 3.8.4+, 3.9.0+    2.17 (2012-12-25)
       # manylinux_x_y  >=20.3   3.8.10+, 3.9.5+, 3.10.0+  x.y
       # manylinux2010 images EOL on 2022-08-01, it doesn't support cp311.
-      CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
+      CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
       CIBW_ARCHS_LINUX: x86_64
 

--- a/README.rst
+++ b/README.rst
@@ -333,16 +333,6 @@ Sometimes it's not clear how zero-width matches should be handled. For example, 
   >>> regex.sub('.*?', '|', 'test')
   '|||||||||'
 
-  # Python 3.6 and earlier
-  >>> regex.sub('(?V0).*', 'x', 'test')
-  'x'
-  >>> regex.sub('(?V1).*', 'x', 'test')
-  'xx'
-  >>> regex.sub('(?V0).*?', '|', 'test')
-  '|t|e|s|t|'
-  >>> regex.sub('(?V1).*?', '|', 'test')
-  '|||||||||'
-
 Added ``capturesdict`` (`Hg issue 86 <https://github.com/mrabarnett/mrab-regex/issues/86>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version: 2023.x
+
+    Stopped supporting Python 3.6.
+
 Version: 2023.6.3
 
     # Git issue 498: Conditional negative lookahead inside positive lookahead fails to match

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -32,11 +31,11 @@ setup(
         'Topic :: Text Processing',
         'Topic :: Text Processing :: General',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 
     package_dir={'regex': 'regex_3'},
     py_modules=['regex.__init__', 'regex.regex', 'regex._regex_core',
-     'regex.test_regex'],
+                'regex.test_regex'],
     ext_modules=[Extension('regex._regex', [join('regex_3', '_regex.c'),
-      join('regex_3', '_regex_unicode.c')])],
+                                            join('regex_3', '_regex_unicode.c')])],
 )


### PR DESCRIPTION
Python 3.7 final has been released, support for 3.6 can be dropped.