### PR TITLE
drop python<=3.7 support

### DIFF
--- a/regex_3/_regex_core.py
+++ b/regex_3/_regex_core.py
@@ -48,7 +48,7 @@ class error(Exception):
             self.lineno = pattern.count(newline, 0, pos) + 1
             self.colno = pos - pattern.rfind(newline, 0, pos)
 
-            message = "{} at position {}".format(message, pos)
+            message = f"{message} at position {pos}"
 
             if newline in pattern:
                 message += " (line {}, column {})".format(self.lineno,
@@ -1318,7 +1318,7 @@ def parse_hex_escape(source, info, esc, expected_len, in_set, type):
     for i in range(expected_len):
         ch = source.get()
         if ch not in HEX_DIGITS:
-            raise error("incomplete escape \\%s%s" % (type, ''.join(digits)),
+            raise error("incomplete escape \\{}{}".format(type, ''.join(digits)),
               source.string, saved_pos)
         digits.append(ch)
 
@@ -1331,7 +1331,7 @@ def parse_hex_escape(source, info, esc, expected_len, in_set, type):
             return make_character(info, value, in_set)
 
     # Bad hex escape.
-    raise error("bad hex escape \\%s%s" % (esc, ''.join(digits)),
+    raise error("bad hex escape \\{}{}".format(esc, ''.join(digits)),
       source.string, saved_pos)
 
 def parse_group_ref(source, info):
@@ -1617,7 +1617,7 @@ def numeric_to_rational(numeric):
     else:
         raise ValueError()
 
-    result = "{}{}/{}".format(sign, num, den)
+    result = f"{sign}{num}/{den}"
     if result.endswith("/1"):
         return result[ : -2]
 
@@ -1782,7 +1782,7 @@ def parse_repl_hex_escape(source, expected_len, type):
     for i in range(expected_len):
         ch = source.get()
         if ch not in HEX_DIGITS:
-            raise error("incomplete escape \\%s%s" % (type, ''.join(digits)),
+            raise error("incomplete escape \\{}{}".format(type, ''.join(digits)),
               source.string, source.pos)
         digits.append(ch)
 
@@ -1921,7 +1921,7 @@ class ZeroWidthBase(RegexBase):
         self._key = self.__class__, self.positive
 
     def get_firstset(self, reverse):
-        return set([None])
+        return {None}
 
     def _compile(self, reverse, fuzzy):
         flags = 0
@@ -1954,7 +1954,7 @@ class Any(RegexBase):
         return [(self._opcode[reverse], flags)]
 
     def dump(self, indent, reverse):
-        print("{}{}".format(INDENT * indent, self._op_name))
+        print(f"{INDENT * indent}{self._op_name}")
 
     def max_width(self):
         return 1
@@ -2007,7 +2007,7 @@ class Atomic(RegexBase):
           [(OP.END, )])
 
     def dump(self, indent, reverse):
-        print("{}ATOMIC".format(INDENT * indent))
+        print(f"{INDENT * indent}ATOMIC")
         self.subpattern.dump(indent + 1, reverse)
 
     def is_empty(self):
@@ -2108,7 +2108,7 @@ class Branch(RegexBase):
         for b in self.branches:
             fs |= b.get_firstset(reverse)
 
-        return fs or set([None])
+        return fs or {None}
 
     def _compile(self, reverse, fuzzy):
         if not self.branches:
@@ -2124,10 +2124,10 @@ class Branch(RegexBase):
         return code
 
     def dump(self, indent, reverse):
-        print("{}BRANCH".format(INDENT * indent))
+        print(f"{INDENT * indent}BRANCH")
         self.branches[0].dump(indent + 1, reverse)
         for b in self.branches[1 : ]:
-            print("{}OR".format(INDENT * indent))
+            print(f"{INDENT * indent}OR")
             b.dump(indent + 1, reverse)
 
     @staticmethod
@@ -2454,7 +2454,7 @@ class CallGroup(RegexBase):
         return [(OP.GROUP_CALL, self.call_ref)]
 
     def dump(self, indent, reverse):
-        print("{}GROUP_CALL {}".format(INDENT * indent, self.group))
+        print(f"{INDENT * indent}GROUP_CALL {self.group}")
 
     def __eq__(self, other):
         return type(self) is type(other) and self.group == other.group
@@ -2505,7 +2505,7 @@ class Character(RegexBase):
         return self
 
     def get_firstset(self, reverse):
-        return set([self])
+        return {self}
 
     def has_simple_start(self):
         return True
@@ -2618,10 +2618,10 @@ class Conditional(RegexBase):
         return code
 
     def dump(self, indent, reverse):
-        print("{}GROUP_EXISTS {}".format(INDENT * indent, self.group))
+        print(f"{INDENT * indent}GROUP_EXISTS {self.group}")
         self.yes_item.dump(indent + 1, reverse)
         if not self.no_item.is_empty():
-            print("{}OR".format(INDENT * indent))
+            print(f"{INDENT * indent}OR")
             self.no_item.dump(indent + 1, reverse)
 
     def is_empty(self):
@@ -2766,7 +2766,7 @@ class Fuzzy(RegexBase):
         constraints = self._constraints_to_string()
         if constraints:
             constraints = " " + constraints
-        print("{}FUZZY{}".format(INDENT * indent, constraints))
+        print(f"{INDENT * indent}FUZZY{constraints}")
         self.subpattern.dump(indent + 1, reverse)
 
     def is_empty(self):
@@ -2790,12 +2790,12 @@ class Fuzzy(RegexBase):
             con = ""
 
             if min > 0:
-                con = "{}<=".format(min)
+                con = f"{min}<="
 
             con += name
 
             if max is not None:
-                con += "<={}".format(max)
+                con += f"<={max}"
 
             constraints.append(con)
 
@@ -2803,7 +2803,7 @@ class Fuzzy(RegexBase):
         for name in "ids":
             coeff = self.constraints["cost"][name]
             if coeff > 0:
-                cost.append("{}{}".format(coeff, name))
+                cost.append(f"{coeff}{name}")
 
         limit = self.constraints["cost"]["max"]
         if limit is not None and limit > 0:
@@ -2822,7 +2822,7 @@ class Grapheme(RegexBase):
         return grapheme_matcher.compile(reverse, fuzzy)
 
     def dump(self, indent, reverse):
-        print("{}GRAPHEME".format(INDENT * indent))
+        print(f"{INDENT * indent}GRAPHEME")
 
     def max_width(self):
         return UNLIMITED
@@ -2942,7 +2942,7 @@ class PossessiveRepeat(GreedyRepeat):
           (OP.END, )])
 
     def dump(self, indent, reverse):
-        print("{}ATOMIC".format(INDENT * indent))
+        print(f"{INDENT * indent}ATOMIC")
 
         if self.max_count is None:
             limit = "INF"
@@ -3019,7 +3019,7 @@ class Group(RegexBase):
         group = self.group
         if group < 0:
             group = private_groups[group]
-        print("{}GROUP {}".format(INDENT * indent, group))
+        print(f"{INDENT * indent}GROUP {group}")
         self.subpattern.dump(indent + 1, reverse)
 
     def __eq__(self, other):
@@ -3082,7 +3082,7 @@ class LookAround(RegexBase):
         if self.positive and self.behind == reverse:
             return self.subpattern.get_firstset(reverse)
 
-        return set([None])
+        return {None}
 
     def _compile(self, reverse, fuzzy):
         flags = 0
@@ -3176,10 +3176,10 @@ class LookAroundConditional(RegexBase):
         print("{}CONDITIONAL {} {}".format(INDENT * indent,
           self._dir_text[self.behind], POS_TEXT[self.positive]))
         self.subpattern.dump(indent + 1, self.behind)
-        print("{}EITHER".format(INDENT * indent))
+        print(f"{INDENT * indent}EITHER")
         self.yes_item.dump(indent + 1, reverse)
         if not self.no_item.is_empty():
-            print("{}OR".format(INDENT * indent))
+            print(f"{INDENT * indent}OR")
             self.no_item.dump(indent + 1, reverse)
 
     def is_empty(self):
@@ -3228,7 +3228,7 @@ class Property(RegexBase):
         return self
 
     def get_firstset(self, reverse):
-        return set([self])
+        return {self}
 
     def has_simple_start(self):
         return True
@@ -3477,7 +3477,7 @@ class Sequence(RegexBase):
                 return fs
             fs.discard(None)
 
-        return fs | set([None])
+        return fs | {None}
 
     def has_simple_start(self):
         return bool(self.items) and self.items[0].has_simple_start()
@@ -3624,7 +3624,7 @@ class SetBase(RegexBase):
           zerowidth).optimise(self.info, False)
 
     def get_firstset(self, reverse):
-        return set([self])
+        return {self}
 
     def has_simple_start(self):
         return True
@@ -3913,8 +3913,8 @@ class String(RegexBase):
             pos = -1
         else:
             pos = 0
-        return set([Character(self.characters[pos],
-          case_flags=self.case_flags)])
+        return {Character(self.characters[pos],
+          case_flags=self.case_flags)}
 
     def has_simple_start(self):
         return True
@@ -4185,7 +4185,7 @@ class Source:
 
     def expect(self, substring):
         if not self.match(substring):
-            raise error("missing {}".format(substring), self.string, self.pos)
+            raise error(f"missing {substring}", self.string, self.pos)
 
     def at_end(self):
         string = self.string

--- a/regex_3/regex.py
+++ b/regex_3/regex.py
@@ -476,7 +476,7 @@ def _compile(pattern, flags, ignore_unused, kwargs, cache_it):
         unused_kwargs = set(kwargs) - {k for k, v in args_needed}
         if unused_kwargs:
             any_one = next(iter(unused_kwargs))
-            raise ValueError('unused keyword argument {!a}'.format(any_one))
+            raise ValueError(f'unused keyword argument {any_one!a}')
 
     if cache_it:
         try:
@@ -491,7 +491,7 @@ def _compile(pattern, flags, ignore_unused, kwargs, cache_it):
                     try:
                         args_supplied.add((k, frozenset(kwargs[k])))
                     except KeyError:
-                        raise error("missing named list: {!r}".format(k))
+                        raise error(f"missing named list: {k!r}")
 
             complain_unused_args()
 
@@ -639,7 +639,7 @@ def _compile(pattern, flags, ignore_unused, kwargs, cache_it):
             pass
 
     # The named capture groups.
-    index_group = dict((v, n) for n, v in info.group_index.items())
+    index_group = {v: n for n, v in info.group_index.items()}
 
     # Create the PatternObject.
     #

--- a/regex_3/test_regex.py
+++ b/regex_3/test_regex.py
@@ -3,7 +3,6 @@ import copy
 import pickle
 import regex
 import string
-import sys
 import unittest
 
 # String subclasses for issue 18468.

--- a/regex_3/test_regex.py
+++ b/regex_3/test_regex.py
@@ -210,10 +210,7 @@ class RegexTests(unittest.TestCase):
 
     def test_bug_462270(self):
         # Test for empty sub() behaviour, see SF bug #462270
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.sub('(?V0)x*', '-', 'abxd'), '-a-b--d-')
-        else:
-            self.assertEqual(regex.sub('(?V0)x*', '-', 'abxd'), '-a-b-d-')
+        self.assertEqual(regex.sub('(?V0)x*', '-', 'abxd'), '-a-b--d-')
         self.assertEqual(regex.sub('(?V1)x*', '-', 'abxd'), '-a-b--d-')
         self.assertEqual(regex.sub('x+', '-', 'abxd'), 'ab-d')
 
@@ -255,23 +252,14 @@ class RegexTests(unittest.TestCase):
 
     def test_re_split(self):
         self.assertEqual(regex.split(":", ":a:b::c"), ['', 'a', 'b', '', 'c'])
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.split(":*", ":a:b::c"), ['', '', 'a', '',
-              'b', '', 'c', ''])
-            self.assertEqual(regex.split("(:*)", ":a:b::c"), ['', ':', '', '',
-              'a', ':', '', '', 'b', '::', '', '', 'c', '', ''])
-            self.assertEqual(regex.split("(?::*)", ":a:b::c"), ['', '', 'a',
-              '', 'b', '', 'c', ''])
-            self.assertEqual(regex.split("(:)*", ":a:b::c"), ['', ':', '',
-              None, 'a', ':', '', None, 'b', ':', '', None, 'c', None, ''])
-        else:
-            self.assertEqual(regex.split(":*", ":a:b::c"), ['', 'a', 'b', 'c'])
-            self.assertEqual(regex.split("(:*)", ":a:b::c"), ['', ':', 'a',
-              ':', 'b', '::', 'c'])
-            self.assertEqual(regex.split("(?::*)", ":a:b::c"), ['', 'a', 'b',
-              'c'])
-            self.assertEqual(regex.split("(:)*", ":a:b::c"), ['', ':', 'a',
-              ':', 'b', ':', 'c'])
+        self.assertEqual(regex.split(":*", ":a:b::c"), ['', '', 'a', '',
+          'b', '', 'c', ''])
+        self.assertEqual(regex.split("(:*)", ":a:b::c"), ['', ':', '', '',
+          'a', ':', '', '', 'b', '::', '', '', 'c', '', ''])
+        self.assertEqual(regex.split("(?::*)", ":a:b::c"), ['', '', 'a',
+          '', 'b', '', 'c', ''])
+        self.assertEqual(regex.split("(:)*", ":a:b::c"), ['', ':', '',
+          None, 'a', ':', '', None, 'b', ':', '', None, 'c', None, ''])
         self.assertEqual(regex.split("([b:]+)", ":a:b::c"), ['', ':', 'a',
           ':b::', 'c'])
         self.assertEqual(regex.split("(b)|(:+)", ":a:b::c"), ['', None, ':',
@@ -310,12 +298,8 @@ class RegexTests(unittest.TestCase):
         self.assertEqual(regex.split("(:)", ":a:b::c", 2), ['', ':', 'a', ':',
           'b::c'])
 
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.split("(:*)", ":a:b::c", 2), ['', ':', '',
-              '', 'a:b::c'])
-        else:
-            self.assertEqual(regex.split("(:*)", ":a:b::c", 2), ['', ':', 'a',
-              ':', 'b::c'])
+        self.assertEqual(regex.split("(:*)", ":a:b::c", 2), ['', ':', '',
+          '', 'a:b::c'])
 
     def test_re_findall(self):
         self.assertEqual(regex.findall(":+", "abc"), [])
@@ -997,7 +981,7 @@ class RegexTests(unittest.TestCase):
         if not m:
             self.fail("Failed: expected match but returned None")
         elif m[:] != ('x', 'x'):
-            self.fail("Failed: expected \"('x', 'x')\" but got {} instead".format(ascii(m[:])))
+            self.fail(f"Failed: expected \"('x', 'x')\" but got {ascii(m[:])} instead")
 
     def test_new_named_groups(self):
         m0 = regex.match(r'(?P<a>\w)', 'x')
@@ -1178,9 +1162,9 @@ class RegexTests(unittest.TestCase):
         for pattern, chars, expected in tests:
             try:
                 if chars[ : 0].join(regex.findall(pattern, chars)) != expected:
-                    self.fail("Failed: {}".format(pattern))
+                    self.fail(f"Failed: {pattern}")
             except Exception as e:
-                self.fail("Failed: {} raised {}".format(pattern, ascii(e)))
+                self.fail(f"Failed: {pattern} raised {ascii(e)}")
 
         self.assertEqual(bool(regex.match(r"\p{NumericValue=0}", "0")),
           True)
@@ -1335,11 +1319,8 @@ class RegexTests(unittest.TestCase):
 
     def test_zerowidth(self):
         # Issue 3262.
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.split(r"\b", "a b"), ['', 'a', ' ', 'b',
-              ''])
-        else:
-            self.assertEqual(regex.split(r"\b", "a b"), ['a b'])
+        self.assertEqual(regex.split(r"\b", "a b"), ['', 'a', ' ', 'b',
+          ''])
         self.assertEqual(regex.split(r"(?V1)\b", "a b"), ['', 'a', ' ', 'b',
           ''])
 
@@ -1361,25 +1342,15 @@ class RegexTests(unittest.TestCase):
         self.assertEqual([m[0] for m in regex.finditer(r"(?rV1)^|\w+",
           "foo bar")], ['bar', 'foo', ''])
 
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.split("", "xaxbxc"), ['', 'x', 'a', 'x',
-              'b', 'x', 'c', ''])
-            self.assertEqual([m for m in regex.splititer("", "xaxbxc")], ['',
-              'x', 'a', 'x', 'b', 'x', 'c', ''])
-        else:
-            self.assertEqual(regex.split("", "xaxbxc"), ['xaxbxc'])
-            self.assertEqual([m for m in regex.splititer("", "xaxbxc")],
-              ['xaxbxc'])
+        self.assertEqual(regex.split("", "xaxbxc"), ['', 'x', 'a', 'x',
+          'b', 'x', 'c', ''])
+        self.assertEqual([m for m in regex.splititer("", "xaxbxc")], ['',
+          'x', 'a', 'x', 'b', 'x', 'c', ''])
 
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.split("(?r)", "xaxbxc"), ['', 'c', 'x', 'b',
-              'x', 'a', 'x', ''])
-            self.assertEqual([m for m in regex.splititer("(?r)", "xaxbxc")],
-              ['', 'c', 'x', 'b', 'x', 'a', 'x', ''])
-        else:
-            self.assertEqual(regex.split("(?r)", "xaxbxc"), ['xaxbxc'])
-            self.assertEqual([m for m in regex.splititer("(?r)", "xaxbxc")],
-              ['xaxbxc'])
+        self.assertEqual(regex.split("(?r)", "xaxbxc"), ['', 'c', 'x', 'b',
+          'x', 'a', 'x', ''])
+        self.assertEqual([m for m in regex.splititer("(?r)", "xaxbxc")],
+          ['', 'c', 'x', 'b', 'x', 'a', 'x', ''])
 
         self.assertEqual(regex.split("(?V1)", "xaxbxc"), ['', 'x', 'a', 'x',
           'b', 'x', 'c', ''])
@@ -1465,33 +1436,19 @@ class RegexTests(unittest.TestCase):
     def test_unmatched_in_sub(self):
         # Issue 1519638.
 
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "xy"),
-              'y-x-')
-        else:
-            self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "xy"),
-              'y-x')
+        self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "xy"),
+          'y-x-')
         self.assertEqual(regex.sub(r"(?V1)(x)?(y)?", r"\2-\1", "xy"), 'y-x-')
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "x"), '-x-')
-        else:
-            self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "x"), '-x')
+        self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "x"), '-x-')
         self.assertEqual(regex.sub(r"(?V1)(x)?(y)?", r"\2-\1", "x"), '-x-')
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "y"), 'y--')
-        else:
-            self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "y"), 'y-')
+        self.assertEqual(regex.sub(r"(?V0)(x)?(y)?", r"\2-\1", "y"), 'y--')
         self.assertEqual(regex.sub(r"(?V1)(x)?(y)?", r"\2-\1", "y"), 'y--')
 
     def test_bug_10328 (self):
         # Issue 10328.
         pat = regex.compile(r'(?mV0)(?P<trailing_ws>[ \t]+\r*$)|(?P<no_final_newline>(?<=[^\n])\Z)')
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(pat.subn(lambda m: '<' + m.lastgroup + '>',
-              'foobar '), ('foobar<trailing_ws><no_final_newline>', 2))
-        else:
-            self.assertEqual(pat.subn(lambda m: '<' + m.lastgroup + '>',
-              'foobar '), ('foobar<trailing_ws>', 1))
+        self.assertEqual(pat.subn(lambda m: '<' + m.lastgroup + '>',
+          'foobar '), ('foobar<trailing_ws><no_final_newline>', 2))
         self.assertEqual([m.group() for m in pat.finditer('foobar ')], [' ',
           ''])
         pat = regex.compile(r'(?mV1)(?P<trailing_ws>[ \t]+\r*$)|(?P<no_final_newline>(?<=[^\n])\Z)')
@@ -2447,7 +2404,7 @@ xyzabc
                     pattern, string, groups, expected, excval = t
             except ValueError:
                 fields = ", ".join([ascii(f) for f in t[ : 3]] + ["..."])
-                self.fail("Incorrect number of test fields: ({})".format(fields))
+                self.fail(f"Incorrect number of test fields: ({fields})")
             else:
                 group_list = []
                 if groups:
@@ -2576,9 +2533,9 @@ xyzabc
           bar=["one", "two", "three"]))), self.PATTERN_CLASS)
 
         self.assertEqual(regex.findall(r"^\L<options>", "solid QWERT",
-          options=set(['good', 'brilliant', '+s\\ol[i}d'])), [])
+          options={'good', 'brilliant', '+s\\ol[i}d'}), [])
         self.assertEqual(regex.findall(r"^\L<options>", "+solid QWERT",
-          options=set(['good', 'brilliant', '+solid'])), ['+solid'])
+          options={'good', 'brilliant', '+solid'}), ['+solid'])
 
         options = ["STRASSE"]
         self.assertEqual(regex.match(r"(?fi)\L<words>",
@@ -2967,32 +2924,20 @@ xyzabc
         for string in ":a:b::c", StrSubclass(":a:b::c"):
             self.assertTypedEqual(regex.split(":", string), ['', 'a', 'b', '',
               'c'])
-            if sys.version_info >= (3, 7, 0):
-                self.assertTypedEqual(regex.split(":*", string), ['', '', 'a',
-                  '', 'b', '', 'c', ''])
-                self.assertTypedEqual(regex.split("(:*)", string), ['', ':',
-                  '', '', 'a', ':', '', '', 'b', '::', '', '', 'c', '', ''])
-            else:
-                self.assertTypedEqual(regex.split(":*", string), ['', 'a', 'b',
-                  'c'])
-                self.assertTypedEqual(regex.split("(:*)", string), ['', ':',
-                  'a', ':', 'b', '::', 'c'])
+            self.assertTypedEqual(regex.split(":*", string), ['', '', 'a',
+              '', 'b', '', 'c', ''])
+            self.assertTypedEqual(regex.split("(:*)", string), ['', ':',
+              '', '', 'a', ':', '', '', 'b', '::', '', '', 'c', '', ''])
 
         for string in (b":a:b::c", BytesSubclass(b":a:b::c"),
           bytearray(b":a:b::c"), memoryview(b":a:b::c")):
             self.assertTypedEqual(regex.split(b":", string), [b'', b'a', b'b',
               b'', b'c'])
-            if sys.version_info >= (3, 7, 0):
-                self.assertTypedEqual(regex.split(b":*", string), [b'', b'',
-                  b'a', b'', b'b', b'', b'c', b''])
-                self.assertTypedEqual(regex.split(b"(:*)", string), [b'', b':',
-                  b'', b'', b'a', b':', b'', b'', b'b', b'::', b'', b'', b'c',
-                  b'', b''])
-            else:
-                self.assertTypedEqual(regex.split(b":*", string), [b'', b'a',
-                  b'b', b'c'])
-                self.assertTypedEqual(regex.split(b"(:*)", string), [b'', b':',
-                  b'a', b':', b'b', b'::', b'c'])
+            self.assertTypedEqual(regex.split(b":*", string), [b'', b'',
+              b'a', b'', b'b', b'', b'c', b''])
+            self.assertTypedEqual(regex.split(b"(:*)", string), [b'', b':',
+              b'', b'', b'a', b':', b'', b'', b'b', b'::', b'', b'', b'c',
+              b'', b''])
 
         for string in "a:b::c:::d", StrSubclass("a:b::c:::d"):
             self.assertTypedEqual(regex.findall(":+", string), [":", "::",
@@ -3360,16 +3305,10 @@ xyzabc
         self.assertEqual(pat.findall(raw), ['xxx'])
 
         # Hg issue 106: * operator not working correctly with sub()
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.sub('(?V0).*', 'x', 'test'), 'xx')
-        else:
-            self.assertEqual(regex.sub('(?V0).*', 'x', 'test'), 'x')
+        self.assertEqual(regex.sub('(?V0).*', 'x', 'test'), 'xx')
         self.assertEqual(regex.sub('(?V1).*', 'x', 'test'), 'xx')
 
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.sub('(?V0).*?', '|', 'test'), '|||||||||')
-        else:
-            self.assertEqual(regex.sub('(?V0).*?', '|', 'test'), '|t|e|s|t|')
+        self.assertEqual(regex.sub('(?V0).*?', '|', 'test'), '|||||||||')
         self.assertEqual(regex.sub('(?V1).*?', '|', 'test'), '|||||||||')
 
         # Hg issue 112: re: OK, but regex: SystemError
@@ -4437,16 +4376,15 @@ thing
           'c a b c c b a')
 
     def test_more_zerowidth(self):
-        if sys.version_info >= (3, 7, 0):
-            self.assertEqual(regex.split(r'\b|:+', 'a::bc'), ['', 'a', '', '',
-              'bc', ''])
-            self.assertEqual(regex.sub(r'\b|:+', '-', 'a::bc'), '-a---bc-')
-            self.assertEqual(regex.findall(r'\b|:+', 'a::bc'), ['', '', '::',
-              '', ''])
-            self.assertEqual([m.span() for m in regex.finditer(r'\b|:+',
-              'a::bc')], [(0, 0), (1, 1), (1, 3), (3, 3), (5, 5)])
-            self.assertEqual([m.span() for m in regex.finditer(r'(?m)^\s*?$',
-              'foo\n\n\nbar')], [(4, 4), (4, 5), (5, 5)])
+        self.assertEqual(regex.split(r'\b|:+', 'a::bc'), ['', 'a', '', '',
+          'bc', ''])
+        self.assertEqual(regex.sub(r'\b|:+', '-', 'a::bc'), '-a---bc-')
+        self.assertEqual(regex.findall(r'\b|:+', 'a::bc'), ['', '', '::',
+          '', ''])
+        self.assertEqual([m.span() for m in regex.finditer(r'\b|:+',
+          'a::bc')], [(0, 0), (1, 1), (1, 3), (3, 3), (5, 5)])
+        self.assertEqual([m.span() for m in regex.finditer(r'(?m)^\s*?$',
+          'foo\n\n\nbar')], [(4, 4), (4, 5), (5, 5)])
 
     def test_line_ending(self):
       self.assertEqual(regex.findall(r'\R', '\r\n\n\x0B\f\r\x85\u2028\u2029'),

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -32,7 +31,7 @@ setup(
         'Topic :: Text Processing',
         'Topic :: Text Processing :: General',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 
     package_dir={'regex': 'regex_3'},
     py_modules=['regex.__init__', 'regex.regex', 'regex._regex_core',

--- a/tools/build_regex_unicode.py
+++ b/tools/build_regex_unicode.py
@@ -5,12 +5,10 @@
 #
 # Written by MRAB.
 #
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from io import TextIOWrapper
 from itertools import chain
-from os import listdir, mkdir
 from os.path import basename, dirname, exists, join, normpath
-from time import time
 from urllib.parse import urljoin
 from urllib.request import urlretrieve
 from zipfile import ZipFile


### PR DESCRIPTION
https://endoflife.date/python shows that 3.7 has been EOSed at 27 Jun 2023.
Filter all code over `pyuprade --py38-plus`.