### PR TITLE
Adding clear links to the unicode documentation so that users can find the valid values for the \p{} syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -925,8 +925,8 @@ A short form starting with ``Is`` indicates a script or binary property:
 A short form starting with ``In`` indicates a block property:
 
 * ``InBasicLatin``, the 'BasicLatin' block (``Block=BasicLatin``).
-(`Hg issue 102 <https://github.com/mrabarnett/mrab-regex/issues/102>`_)
-There is a list of (`Unicode properties <https://www.unicode.org/Public/16.0.0/ucd/PropList.txt>`_) lists properties and the characters that have them, plus additional (`unicode documentation <https://www.unicode.org/Public/16.0.0/ucd/>`_) such as documentation of (`scripts <https://www.unicode.org/Public/16.0.0/ucd/Scripts.txt>`_) and (`blocks <https://www.unicode.org/Public/16.0.0/ucd/Blocks.txt>`_).
+
+The  (`Unicode properties <https://www.unicode.org/Public/16.0.0/ucd/PropList.txt>`_), (`scripts <https://www.unicode.org/Public/16.0.0/ucd/Scripts.txt>`_), and (`blocks <https://www.unicode.org/Public/16.0.0/ucd/Blocks.txt>`_) documentation lists properties that you can use with this syntax and the characters that have them.
 
 POSIX character classes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ The issue numbers relate to the Python bug tracker, except where listed otherwis
 Added ``\p{Horiz_Space}`` and ``\p{Vert_Space}`` (`GitHub issue 477 <https://github.com/mrabarnett/mrab-regex/issues/477#issuecomment-1216779547>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``\p{Horiz_Space}`` or ``\p{H}`` matches horizontal whitespace and ``\p{Vert_Space}`` or ``\p{V}`` matches vertical whitespace.  
+``\p{Horiz_Space}`` or ``\p{H}`` matches horizontal whitespace and ``\p{Vert_Space}`` or ``\p{V}`` matches vertical whitespace.
 
 Added support for lookaround in conditional pattern (`Hg issue 163 <https://github.com/mrabarnett/mrab-regex/issues/163>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -925,8 +925,8 @@ A short form starting with ``Is`` indicates a script or binary property:
 A short form starting with ``In`` indicates a block property:
 
 * ``InBasicLatin``, the 'BasicLatin' block (``Block=BasicLatin``).
-
-There is a [list of Unicode properties](https://www.unicode.org/Public/16.0.0/ucd/PropList.txt) lists properties and the characters that have them, plus additional [unicode documentation](https://www.unicode.org/Public/16.0.0/ucd/) such as documentation of [scripts](https://www.unicode.org/Public/16.0.0/ucd/Scripts.txt) and [blocks](https://www.unicode.org/Public/16.0.0/ucd/Blocks.txt).
+(`Hg issue 102 <https://github.com/mrabarnett/mrab-regex/issues/102>`_)
+There is a list of (`Unicode properties <https://www.unicode.org/Public/16.0.0/ucd/PropList.txt>`_) lists properties and the characters that have them, plus additional (`unicode documentation <https://www.unicode.org/Public/16.0.0/ucd/>`_) such as documentation of (`scripts <https://www.unicode.org/Public/16.0.0/ucd/Scripts.txt>`_) and (`blocks <https://www.unicode.org/Public/16.0.0/ucd/Blocks.txt>`_).
 
 POSIX character classes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ The issue numbers relate to the Python bug tracker, except where listed otherwis
 Added ``\p{Horiz_Space}`` and ``\p{Vert_Space}`` (`GitHub issue 477 <https://github.com/mrabarnett/mrab-regex/issues/477#issuecomment-1216779547>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``\p{Horiz_Space}`` or ``\p{H}`` matches horizontal whitespace and ``\p{Vert_Space}`` or ``\p{V}`` matches vertical whitespace.
+``\p{Horiz_Space}`` or ``\p{H}`` matches horizontal whitespace and ``\p{Vert_Space}`` or ``\p{V}`` matches vertical whitespace.  
 
 Added support for lookaround in conditional pattern (`Hg issue 163 <https://github.com/mrabarnett/mrab-regex/issues/163>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -925,6 +925,8 @@ A short form starting with ``Is`` indicates a script or binary property:
 A short form starting with ``In`` indicates a block property:
 
 * ``InBasicLatin``, the 'BasicLatin' block (``Block=BasicLatin``).
+
+There is a [list of Unicode properties](https://www.unicode.org/Public/16.0.0/ucd/PropList.txt) lists properties and the characters that have them, plus additional [unicode documentation](https://www.unicode.org/Public/16.0.0/ucd/) such as documentation of [scripts](https://www.unicode.org/Public/16.0.0/ucd/Scripts.txt) and [blocks](https://www.unicode.org/Public/16.0.0/ucd/Blocks.txt).
 
 POSIX character classes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/regex_3/regex.py
+++ b/regex_3/regex.py
@@ -144,7 +144,8 @@ second character.
     \n              Matches the newline character.
     \N{name}        Matches the named character.
     \p{name=value}  Matches the character if its property has the specified
-                    value.
+                    value.  A list of unicode properties and the characters that 
+                    have them is available here:  https://www.unicode.org/Public/16.0.0/ucd/PropList.txt
     \P{name=value}  Matches the character if its property hasn't the specified
                     value.
     \r              Matches the carriage-return character.


### PR DESCRIPTION
I very much appreciate this library but have struggled to find the definitions of things like \p{Initial_Punctuation} so, this PR adds that documentation in a couple of useful places.  Feel free to improve upon it!