### PR TITLE
pyproject.toml: fix version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "regex"
-version = "2024.11.6"
+version = "2025.2.13"
 description = "Alternative regular expression module, to replace re."
 readme = "README.rst"
 authors = [


### PR DESCRIPTION
It appears that the version string was not updated when the code was tagged. As a result, when building wheels for the latest tags (2024.11.7, 2025.2.10, 2025.2.11, 2025.2.12, 2025.2.13), the wheels are still showing version 2024.11.6.