### PR TITLE
Build Windows ARM64/aarch64 wheel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
     env:
       # macOS archs
       CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
+      # Windows archs
+      CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
On Windows ARM, the user must build the `regex` wheel locally, which requires installation of compiler tools. This PR instead tells cibuildwheel to build a Windows ARM64 wheel in addition to the already handled `x86` and `AMD64` targets.

This was tested in Github Actions and produced a working wheel, installable without local build on Windows 11 Pro ARM64. I tested that it will import in Python, but did not extensively test the module other than that.

```
Z:\>pip install regex-2024.11.6-cp313-cp313-win_arm64.whl
Processing z:\regex-2024.11.6-cp313-cp313-win_arm64.whl
Installing collected packages: regex
Successfully installed regex-2024.11.6

[notice] A new release of pip is available: 25.0.1 -> 25.1.1
[notice] To update, run: python.exe -m pip install --upgrade pip

Z:\>python
Python 3.13.3 (tags/v3.13.3:6280bb5, Apr  8 2025, 15:28:43) [MSC v.1943 64 bit (ARM64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import regex
>>> 
```

I ran a couple of lines of code from the README, and they worked as expected:

```
>>> regex.match(r'(?(?=\d)\d+|\w+)', '123abc')
<regex.Match object; span=(0, 3), match='123'>
>>> regex.match(r'(?(?=\d)\d+|\w+)', 'abc123')
<regex.Match object; span=(0, 6), match='abc123'>
```