### PR TITLE
Fix AttributeError: 'AnyAll' object has no attribute '_key'

### DIFF
--- a/regex_3/_regex_core.py
+++ b/regex_3/_regex_core.py
@@ -1997,6 +1997,7 @@ class AnyAll(Any):
     _op_name = "ANY_ALL"
 
     def __init__(self):
+      Any.__init__(self)
       self.positive = True
       self.zerowidth = False
       self.case_flags = 0

--- a/regex_3/test_regex.py
+++ b/regex_3/test_regex.py
@@ -4405,6 +4405,9 @@ thing
         # Git issue 584: AttributeError: 'AnyAll' object has no attribute 'positive'
         self.assertEqual(bool(regex.compile('(\\s|\\S)')), True)
 
+        # AttributeError: 'AnyAll' object has no attribute '_key'
+        self.assertEqual(bool(regex.compile('(?:[\\S\\s]|[A-D][M-Z])')), True)
+
     def test_fuzzy_ext(self):
         self.assertEqual(bool(regex.fullmatch(r'(?r)(?:a){e<=1:[a-z]}', 'e')),
           True)


### PR DESCRIPTION
The most recent changes to the `AnyAll` class introduced a bug where the base class was not properly initialized. Specifically, the `_key` attribute, normally set in the base class constructor, remained unset and led to runtime errors.

This PR addresses the issue by explicitly invoking the parent constructor in `AnyAll.__init__`.

Example of the error prior to this fix:

```bash
Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import regex
>>> regex.compile('(?:[\\S\\s]|[A-D][M-Z])')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/.../.venv/lib/python3.10/site-packages/regex/regex.py", line 353, in compile
    return _compile(pattern, flags, ignore_unused, kwargs, cache_pattern)
  File "/home/.../.venv/lib/python3.10/site-packages/regex/regex.py", line 587, in _compile
    parsed = parsed.optimise(info, reverse)
  File "/home/.../.venv/lib/python3.10/site-packages/regex/_regex_core.py", line 3454, in optimise
    s = s.optimise(info, reverse)
  File "/home/.../.venv/lib/python3.10/site-packages/regex/_regex_core.py", line 2091, in optimise
    prefix, branches = Branch._split_common_prefix(info, branches)
  File "/home/.../.venv/lib/python3.10/site-packages/regex/_regex_core.py", line 2204, in _split_common_prefix
    while pos < end_pos and prefix[pos].can_be_affix() and all(a[pos] ==
  File "/home/.../.venv/lib/python3.10/site-packages/regex/_regex_core.py", line 2204, in <genexpr>
    while pos < end_pos and prefix[pos].can_be_affix() and all(a[pos] ==
  File "/home/.../.venv/lib/python3.10/site-packages/regex/_regex_core.py", line 1938, in __eq__
    return type(self) is type(other) and self._key == other._key
AttributeError: 'AnyAll' object has no attribute '_key'
```