### PR TITLE
Only release to PyPI if the test suite reports green

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,31 +13,9 @@ env:
   CIBW_TEST_COMMAND: python -m unittest regex.tests.test_regex
 
 jobs:
-  # Run test on Ubuntu/macOS/Windows for every commit.
-  run_test:
-    name: Run test on ${{ matrix.platform }}
-    runs-on: ${{ matrix.platform }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VER }}
-
-      - name: Run test
-        run: |
-          python -m pip install -vv .
-          python -m unittest -v regex.tests.test_regex
-
   # Build source distribution
   build_source:
     name: Build Source
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -56,6 +34,34 @@ jobs:
         with:
           name: regex-files-source
           path: dist/*.tar.gz
+
+  # Run test on Ubuntu/macOS/Windows for every commit.
+  run_test:
+    name: Run test on ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
+    needs: [build_source]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Download source distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: regex-files-source
+          path: dist
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VER }}
+
+      - name: Run test
+        shell: bash
+        run: |
+          python -m pip install -vv dist/*.tar.gz
+          python -m unittest -v regex.tests.test_regex
 
   # Build Linux/macOS/Windows wheels.
   build_wheels:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
   # Upload to PyPI
   upload_pypi:
     name: Publish to PyPI
-    needs: [build_source, build_wheels, build_in_manylinux2014, build_arch_wheels]
+    needs: [run_test, build_source, build_wheels, build_in_manylinux2014, build_arch_wheels]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
 


### PR DESCRIPTION
This would have prevented the broken release 2025.10.22 from going out, see #590 