### PR TITLE
fix: include setup.py in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include docs/Features.html
 include docs/UnicodeProperties.rst
 include LICENSE.txt
 include pyproject.toml
+include setup.py
 include README.rst
 include regex/__init__.py
 include regex/_main.py


### PR DESCRIPTION
Got implicitely removed in 54fa96c292, but is required for the extension build.

Closes #590