### PR TITLE
ci: add riscv64 manylinux/musllinux wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
           name: regex-files-manylinux2014
           path: wheelhouse/*.whl
 
-  # Build and upload aarch64/ppc64le/s390x wheels.
+  # Build and upload aarch64/ppc64le/riscv64/s390x wheels.
   build_arch_wheels:
     name: Build ${{ matrix.arch }} Linux wheels
     if: github.event_name == 'push'
@@ -152,7 +152,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [aarch64, ppc64le, s390x]
+        arch: [aarch64, ppc64le, riscv64, s390x]
 
     env:
       CIBW_ARCHS_LINUX: ${{ matrix.arch }}


### PR DESCRIPTION
Recent versions of cibuildwheel support riscv64, so we can now start building riscv64 wheels.