### PR TITLE
Added \z to match its support in Python 3.14

### DIFF
--- a/regex/_main.py
+++ b/regex/_main.py
@@ -166,7 +166,8 @@ second character.
     \W              Matches the complement of \w; equivalent to [^\w].
     \xXX            Matches the character with 2-digit hex code XX.
     \X              Matches a grapheme.
-    \Z              Matches only at the end of the string.
+    \z              Matches only at the end of the string.
+    \Z              The same as \z. For compatibility with old Python versions.
     \\              Matches a literal backslash.
 
 This module exports the following functions:

--- a/regex/_regex_core.py
+++ b/regex/_regex_core.py
@@ -4640,6 +4640,7 @@ POSITION_ESCAPES = {
     "K": Keep(),
     "m": StartOfWord(),
     "M": EndOfWord(),
+    "z": EndOfString(),
     "Z": EndOfString(),
 }
 ASCII_POSITION_ESCAPES = dict(POSITION_ESCAPES)


### PR DESCRIPTION
Python 3.14 added two changes:

- Support for `\z`, with `\Z` kept to support old Python versions
- `\B` now matches an empty input string

This PR adds matching support in `regex` for bullet one.

Some projects may use code such as the following to replace Python's built-in `re` module with `regex`:

```sh
import sys
del sys.modules['re']
sys.modules['re'] = __import__('regex') 
```

Doing so allows more complex regular expressions to be used with other modules that rely on the built-in `re` module (ex. [ply](https://github.com/dabeaz/ply)). Although this used to work well, now that `\z` is supported in Python 3.14 and [it is used in cpython sources](https://github.com/python/cpython/blob/3.14/Lib/textwrap.py#L89), this technique fails to work. After running the above example code, you can reproduce this error by importing `unittest` or `textwrap`, like so:

```sh
python3 -c "import sys; del sys.modules['re']; sys.modules['re'] = __import__('regex'); import unittest"
# Traceback (most recent call last):
# ... snip ...
#     raise error(caught_exception.msg, caught_exception.pattern,
# regex._regex_core.error: bad escape \z at position 390 (line 15, column 13)
```

This PR allows `regex` to continue to match the built-in `re` module well enough that it may be used to fully replace `re` in Python 3.14.