### PR TITLE
Preserve Python Exceptions in Input Decoding and String Detachment

### DIFF
--- a/src/_regex.c
+++ b/src/_regex.c
@@ -20279,14 +20279,15 @@ static PyObject* match_detach_string(MatchObject* self, PyObject* unused) {
         determine_target_substring(self, &start, &end);
 
         substring = get_slice(self->string, start, end);
-        if (substring) {
-            Py_XDECREF(self->substring);
-            self->substring = substring;
-            self->substring_offset = start;
+        if (!substring)
+            return NULL;
 
-            Py_DECREF(self->string);
-            self->string = NULL;
-        }
+        Py_XDECREF(self->substring);
+        self->substring = substring;
+        self->substring_offset = start;
+
+        Py_DECREF(self->string);
+        self->string = NULL;
     }
 
     Py_RETURN_NONE;

--- a/src/_regex.c
+++ b/src/_regex.c
@@ -18245,10 +18245,8 @@ Py_LOCAL_INLINE(BOOL) get_string(PyObject* string, RE_StringInfo* str_info) {
     }
 
     /* Get pointer to string buffer. */
-    if (PyObject_GetBuffer(string, &str_info->view, PyBUF_SIMPLE) != 0) {
-        PyErr_SetString(PyExc_TypeError, "expected string or buffer");
+    if (PyObject_GetBuffer(string, &str_info->view, PyBUF_SIMPLE) != 0)
         return FALSE;
-    }
 
     if (!str_info->view.buf) {
         PyBuffer_Release(&str_info->view);
@@ -21044,7 +21042,7 @@ Py_LOCAL_INLINE(int) decode_concurrent(PyObject* concurrent) {
 }
 
 /* Decodes a 'partial' argument. */
-Py_LOCAL_INLINE(BOOL) decode_partial(PyObject* partial) {
+Py_LOCAL_INLINE(int) decode_partial(PyObject* partial) {
     Py_ssize_t value;
 
     if (partial == Py_False)
@@ -21054,10 +21052,8 @@ Py_LOCAL_INLINE(BOOL) decode_partial(PyObject* partial) {
         return TRUE;
 
     value = PyLong_AsLong(partial);
-    if (value == -1 && PyErr_Occurred()) {
-        PyErr_Clear();
-        return TRUE;
-    }
+    if (value == -1 && PyErr_Occurred())
+        return -1;
 
     return value != 0;
 }
@@ -21087,7 +21083,7 @@ static PyObject* pattern_scanner(PatternObject* pattern, PyObject* args,
     Py_ssize_t end;
     int conc;
     Py_ssize_t tim;
-    BOOL part;
+    int part;
 
     PyObject* string;
     PyObject* pos = Py_None;
@@ -21119,6 +21115,8 @@ static PyObject* pattern_scanner(PatternObject* pattern, PyObject* args,
         return NULL;
 
     part = decode_partial(partial);
+    if (part < 0)
+        return NULL;
 
     /* Create a scanner object. */
     self = PyObject_NEW(ScannerObject, &Scanner_Type);
@@ -21536,7 +21534,7 @@ Py_LOCAL_INLINE(PyObject*) pattern_search_or_match(PatternObject* self,
     Py_ssize_t end;
     int conc;
     Py_ssize_t tim;
-    BOOL part;
+    int part;
     RE_State state;
     int status;
     PyObject* match;
@@ -21593,6 +21591,8 @@ Py_LOCAL_INLINE(PyObject*) pattern_search_or_match(PatternObject* self,
         return NULL;
 
     part = decode_partial(partial);
+    if (part < 0)
+        return NULL;
 
     /* The MatchObject, and therefore repeated captures, will be visible. */
     if (!state_init(&state, self, string, start, end, FALSE, conc, part, FALSE,


### PR DESCRIPTION
This pull request improves exception handling in several C API call paths in _regex.c.

Preserve buffer acquisition errors in get_string()
In get_string(), non-Unicode inputs are processed through the buffer protocol using PyObject_GetBuffer(). When buffer acquisition fails, the Python C API has already set the relevant exception. The previous implementation replaced that exception with a generic TypeError stating that a string or buffer was expected.

The function now returns immediately after PyObject_GetBuffer() fails. This preserves the original exception and allows the existing callers, including state_init(), to propagate it to the Python layer without changing the error context.

Propagate invalid partial argument errors
The decode_partial() helper converts non-boolean partial values with PyLong_AsLong(). Previously, conversion failures were cleared and the value was treated as True. This allowed an invalid argument to continue through scanner and matching initialization.

The helper now returns an explicit error state when conversion fails. Both callers, pattern_scanner() and pattern_search_or_match(), check this state and return NULL, preserving the original Python exception.

Correct string detachment failure handling
The get_slice() helper delegates Unicode slicing to unicode_slice() and bytes slicing to bytes_slice(). These paths use Python APIs that may return NULL and set an exception when creating the requested substring fails.

Previously, match_detach_string() only processed the substring when the result was non-NULL. If slicing failed, it continued to return None even though an exception was still set. The function now returns NULL immediately when get_slice() fails.

This correctly covers both Unicode and bytes substring creation paths and prevents the function from returning a successful result while an exception remains pending.