### PR TITLE
Prevent Invalid Pointer Use and Exception State Corruption in Byte String Joining

### DIFF
--- a/src/_regex.c
+++ b/src/_regex.c
@@ -19785,12 +19785,26 @@ Py_LOCAL_INLINE(PyObject*) join_bytestrings(PyObject* list) {
     char* to_bytes;
 
     count = PyList_Size(list);
+    if (count < 0)
+        return NULL;
 
     /* How long will the result be? */
     length = 0;
 
-    for (i = 0; i < count; i++)
-        length += PyBytes_Size(PyList_GetItem(list, i));
+    for (i = 0; i < count; i++) {
+        PyObject* bytestring;
+        Py_ssize_t bytes_length;
+
+        bytestring = PyList_GetItem(list, i);
+        if (!bytestring)
+            return NULL;
+
+        bytes_length = PyBytes_Size(bytestring);
+        if (bytes_length < 0)
+            return NULL;
+
+        length += bytes_length;
+    }
 
     /* Create the resulting bytestring, but uninitialised. */
     result = PyBytes_FromStringAndSize(NULL, length);
@@ -19799,6 +19813,9 @@ Py_LOCAL_INLINE(PyObject*) join_bytestrings(PyObject* list) {
 
     /* Fill the resulting bytestring. */
     to_bytes = PyBytes_AsString(result);
+    if (!to_bytes)
+        goto error;
+
     length = 0;
 
     for (i = 0; i < count; i++) {
@@ -19807,13 +19824,26 @@ Py_LOCAL_INLINE(PyObject*) join_bytestrings(PyObject* list) {
         Py_ssize_t from_length;
 
         bytestring = PyList_GetItem(list, i);
+        if (!bytestring)
+            goto error;
+
         from_bytes = PyBytes_AsString(bytestring);
+        if (!from_bytes)
+            goto error;
+
         from_length = PyBytes_Size(bytestring);
+        if (from_length < 0)
+            goto error;
+
         memmove(to_bytes + length, from_bytes, from_length);
         length += from_length;
     }
 
     return result;
+
+error:
+    Py_DECREF(result);
+    return NULL;
 }
 
 /* Joins a list of strings. */

--- a/src/_regex.c
+++ b/src/_regex.c
@@ -26401,8 +26401,8 @@ static PyObject* get_all_cases(PyObject* self_, PyObject* args) {
     if ((flags & RE_FULL_CASE_FOLDING) == RE_FULL_CASE_FOLDING) {
         count = encoding->full_case_fold(&locale_info, (Py_UCS4)character,
           folded);
-        if (count > 1)
-            PyList_Append(result, Py_None);
+                if (count > 1 && PyList_Append(result, Py_None) < 0)
+                        goto error;
     }
 
     return result;


### PR DESCRIPTION
This pull request fixes unchecked Python C API results in join_bytestrings() and get_all_cases() in _regex.c.

Problem
join_bytestrings() assumes that all list and bytes-related API calls succeed. However, Python C APIs can signal failure by returning NULL or -1 and setting a Python exception. Continuing execution after such a failure can cause the code to:

Pass a NULL object to another Python C API;
Pass an invalid buffer pointer to memmove();
Use an invalid or negative byte length;
Return a non-NULL object while an exception is still set;
Cause a SystemError, process crash, or inconsistent runtime state.
The affected code performs two passes over the input list. The first pass calculates the total output length, and the second pass copies each byte string into the result buffer. An unchecked failure in either pass can invalidate the assumptions used by the following operations.

get_all_cases() has a separate issue. If PyList_Append() fails while adding the full case-folding marker, the original implementation ignores the failure and returns the list anyway. This can leave a Python exception pending while the function returns a non-NULL object, resulting in incorrect exception propagation and potential SystemError behavior.

Changes
The following checks were added to join_bytestrings():

Check the return value of PyList_Size().
Check every PyList_GetItem() call.
Check every PyBytes_Size() call.
Check PyBytes_AsString() for the destination buffer.
Check PyBytes_AsString() for every source byte string.
Release the partially allocated result object if an error occurs during the copy phase.
The return value of PyList_Append() is also checked in get_all_cases(). If appending fails, the function now follows the existing cleanup path and returns NULL.

Impact
These changes prevent the code from continuing with invalid pointers or lengths after a Python C API failure. They also ensure that Python exceptions are preserved and propagated correctly instead of being hidden by a later crash or an inconsistent non-NULL return value.

The changes are important for robustness because failures can occur during memory allocation, object access, buffer access, or list operations. Although these paths are normally successful for internally constructed data, unchecked C API results can turn an otherwise recoverable Python exception into an interpreter crash or an unclear SystemError.

Normal byte-string joining, replacement processing, case-folding behavior, and successful execution remain unchanged.

