### PR TITLE
Propagate Allocation and Internal Errors During Pattern Compilation and Scanner Execution

### DIFF
--- a/src/_regex.c
+++ b/src/_regex.c
@@ -23633,8 +23633,10 @@ Py_LOCAL_INLINE(BOOL) NodeStack_push(RE_NodeStack* stack, RE_Node* node) {
 
         new_items = (RE_Node**)PyMem_Realloc(stack->items, new_capacity *
           sizeof(RE_Node*));
-        if (!new_items)
+        if (!new_items) {
+            PyErr_NoMemory();
             return FALSE;
+        }
 
         stack->capacity = new_capacity;
         stack->items = new_items;
@@ -23651,7 +23653,7 @@ Py_LOCAL_INLINE(RE_Node*) NodeStack_pop(RE_NodeStack* stack) {
 }
 
 /* Marks nodes which are being used as used. */
-Py_LOCAL_INLINE(void) use_nodes(RE_Node* node) {
+Py_LOCAL_INLINE(BOOL) use_nodes(RE_Node* node) {
     RE_NodeStack stack;
 
     NodeStack_init(&stack);
@@ -23661,7 +23663,8 @@ Py_LOCAL_INLINE(void) use_nodes(RE_Node* node) {
             node->status |= RE_STATUS_USED;
             if (!(node->status & RE_STATUS_STRING)) {
                 if (node->nonstring.next_2.node)
-                    NodeStack_push(&stack, node->nonstring.next_2.node);
+                    if (!NodeStack_push(&stack, node->nonstring.next_2.node))
+                        goto error;
             }
             node = node->next_1.node;
         }
@@ -23669,21 +23672,28 @@ Py_LOCAL_INLINE(void) use_nodes(RE_Node* node) {
     }
 
     NodeStack_fini(&stack);
+    return TRUE;
+
+error:
+    NodeStack_fini(&stack);
+    return FALSE;
 }
 
 /* Discards any unused nodes.
  *
  * Optimising the nodes might result in some nodes no longer being used.
  */
-Py_LOCAL_INLINE(void) discard_unused_nodes(PatternObject* pattern) {
+Py_LOCAL_INLINE(BOOL) discard_unused_nodes(PatternObject* pattern) {
     size_t i;
     size_t new_count;
 
     /* Mark the nodes which are being used. */
-    use_nodes(pattern->start_node);
+    if (!use_nodes(pattern->start_node))
+        return FALSE;
 
     for (i = 0; i < pattern->call_ref_info_capacity; i++)
-        use_nodes(pattern->call_ref_info[i].node);
+        if (!use_nodes(pattern->call_ref_info[i].node))
+            return FALSE;
 
     new_count = 0;
     for (i = 0; i < pattern->node_count; i++) {
@@ -23703,6 +23713,7 @@ Py_LOCAL_INLINE(void) discard_unused_nodes(PatternObject* pattern) {
     }
 
     pattern->node_count = new_count;
+    return TRUE;
 }
 
 /* Marks all the group which are named. Returns FALSE if there's an error. */
@@ -23886,7 +23897,8 @@ Py_LOCAL_INLINE(BOOL) optimise_pattern(PatternObject* pattern) {
     }
 
     /* Discard any unused nodes. */
-    discard_unused_nodes(pattern);
+    if (!discard_unused_nodes(pattern))
+        return FALSE;
 
     /* Set the test nodes. */
     set_test_nodes(pattern);

--- a/src/_regex.c
+++ b/src/_regex.c
@@ -20919,9 +20919,12 @@ Py_LOCAL_INLINE(PyObject*) scanner_search_or_match(ScannerObject* self, BOOL
         } else
             /* Don't allow 2 contiguous zero-width matches. */
             state->must_advance = state->text_pos == state->match_pos;
-    } else
+    } else {
         /* Internal error. */
+        if (!PyErr_Occurred())
+            set_error(self->status, NULL);
         match = NULL;
+    }
 
     /* Release the state lock. */
     release_state_lock((PyObject*)self, state);
@@ -20953,6 +20956,9 @@ static PyObject* scanner_iternext(PyObject* self) {
     PyObject* match;
 
     match = scanner_search((ScannerObject*)self, NULL);
+
+    if (!match)
+        return NULL;
 
     if (match == Py_None) {
         /* No match. */

--- a/src/_regex.c
+++ b/src/_regex.c
@@ -23223,8 +23223,10 @@ Py_LOCAL_INLINE(BOOL) CheckStack_push(RE_CheckStack* stack, RE_Node* node,
 
         new_items = (RE_Check*)PyMem_Realloc(stack->items, new_capacity *
           sizeof(RE_Check));
-        if (!new_items)
+        if (!new_items) {
+            PyErr_NoMemory();
             return FALSE;
+        }
 
         stack->capacity = new_capacity;
         stack->items = new_items;
@@ -23243,13 +23245,14 @@ Py_LOCAL_INLINE(RE_Check*) CheckStack_pop(RE_CheckStack* stack) {
 }
 
 /* Adds guards to repeats which are followed by a reference to a group. */
-Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
+Py_LOCAL_INLINE(BOOL) add_repeat_guards(PatternObject* pattern, RE_Node*
   start_node) {
     RE_CheckStack stack;
 
     CheckStack_init(&stack);
 
-    CheckStack_push(&stack, start_node, RE_STATUS_NEITHER);
+    if (!CheckStack_push(&stack, start_node, RE_STATUS_NEITHER))
+        goto error;
 
     for (;;) {
         RE_Check* check;
@@ -23290,11 +23293,16 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
                     node->status |= RE_STATUS_VISITED_AG | max_status_3(result,
                       branch_1_result, branch_2_result);
                 } else {
-                    CheckStack_push(&stack, node, result);
+                                        if (!CheckStack_push(&stack, node, result))
+                                                goto error;
                     if (!visited_branch_2)
-                        CheckStack_push(&stack, branch_2, RE_STATUS_NEITHER);
+                                                if (!CheckStack_push(&stack, branch_2,
+                                                    RE_STATUS_NEITHER))
+                                                        goto error;
                     if (!visited_branch_1)
-                        CheckStack_push(&stack, branch_1, RE_STATUS_NEITHER);
+                                                if (!CheckStack_push(&stack, branch_1,
+                                                    RE_STATUS_NEITHER))
+                                                        goto error;
                 }
                 break;
             }
@@ -23341,15 +23349,20 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
                     node->status |= RE_STATUS_VISITED_AG | max_status_3(result,
                       body_result, tail_result);
                 } else {
-                    CheckStack_push(&stack, node, result);
+                                        if (!CheckStack_push(&stack, node, result))
+                                                goto error;
                     if (!visited_tail)
-                        CheckStack_push(&stack, tail, RE_STATUS_NEITHER);
+                                                if (!CheckStack_push(&stack, tail,
+                                                    RE_STATUS_NEITHER))
+                                                        goto error;
                     if (!visited_body) {
                         if (limited)
                             body->status |= RE_STATUS_VISITED_AG |
                               RE_STATUS_LIMITED;
                         else
-                            CheckStack_push(&stack, body, RE_STATUS_NEITHER);
+                                                        if (!CheckStack_push(&stack, body,
+                                                            RE_STATUS_NEITHER))
+                                                                goto error;
                     }
                 }
                 break;
@@ -23389,8 +23402,10 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
                     node->status |= RE_STATUS_VISITED_AG | max_status_3(result,
                       RE_STATUS_REPEAT, tail_result);
                 } else {
-                    CheckStack_push(&stack, node, result);
-                    CheckStack_push(&stack, tail, RE_STATUS_NEITHER);
+                    if (!CheckStack_push(&stack, node, result))
+                        goto error;
+                    if (!CheckStack_push(&stack, tail, RE_STATUS_NEITHER))
+                        goto error;
                 }
                 break;
             }
@@ -23418,11 +23433,16 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
                     node->status |= RE_STATUS_VISITED_AG | max_status_4(result,
                       branch_1_result, branch_2_result, RE_STATUS_REF);
                 } else {
-                    CheckStack_push(&stack, node, result);
+                                        if (!CheckStack_push(&stack, node, result))
+                                                goto error;
                     if (!visited_branch_2)
-                        CheckStack_push(&stack, branch_2, RE_STATUS_NEITHER);
+                                                if (!CheckStack_push(&stack, branch_2,
+                                                    RE_STATUS_NEITHER))
+                                                        goto error;
                     if (!visited_branch_1)
-                        CheckStack_push(&stack, branch_1, RE_STATUS_NEITHER);
+                                                if (!CheckStack_push(&stack, branch_1,
+                                                    RE_STATUS_NEITHER))
+                                                        goto error;
                 }
                 break;
             }
@@ -23442,8 +23462,10 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
                 if (visited_tail)
                     node->status |= RE_STATUS_VISITED_AG | RE_STATUS_REF;
                 else {
-                    CheckStack_push(&stack, node, result);
-                    CheckStack_push(&stack, tail, RE_STATUS_NEITHER);
+                    if (!CheckStack_push(&stack, node, result))
+                        goto error;
+                    if (!CheckStack_push(&stack, tail, RE_STATUS_NEITHER))
+                        goto error;
                 }
                 break;
             }
@@ -23470,8 +23492,10 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
                       RE_STATUS_REF);
                     node->status |= RE_STATUS_VISITED_AG | tail_result;
                 } else {
-                    CheckStack_push(&stack, node, result);
-                    CheckStack_push(&stack, node->next_1.node, result);
+                    if (!CheckStack_push(&stack, node, result))
+                        goto error;
+                    if (!CheckStack_push(&stack, node->next_1.node, result))
+                        goto error;
                 }
                 break;
             }
@@ -23481,7 +23505,11 @@ Py_LOCAL_INLINE(RE_STATUS_T) add_repeat_guards(PatternObject* pattern, RE_Node*
 
     CheckStack_fini(&stack);
 
-    return start_node->status & (RE_STATUS_REPEAT | RE_STATUS_REF);
+    return TRUE;
+
+error:
+    CheckStack_fini(&stack);
+    return FALSE;
 }
 
 /* Adds an index to a node's values unless it's already present.
@@ -23838,7 +23866,8 @@ Py_LOCAL_INLINE(BOOL) optimise_pattern(PatternObject* pattern) {
     /* Add position guards for repeat bodies containing a reference to a group
      * or repeat tails followed at some point by a reference to a group.
      */
-    add_repeat_guards(pattern, pattern->start_node);
+    if (!add_repeat_guards(pattern, pattern->start_node))
+        return FALSE;
 
     /* Record the index of repeats and fuzzy sections within the body of atomic
      * and lookaround nodes.


### PR DESCRIPTION
This pull request fixes several error-propagation issues in the pattern compilation and scanner execution paths of `src/_regex.c`.

## Problem

Some internal functions return failure indicators without setting a Python exception, while their callers either ignore the return value or continue processing. Python C extension functions must set an exception before returning an error result. Otherwise, failures may be converted into `SystemError`, silently ignored, or leave internal compiler state incomplete.

The affected paths are:

- Check-stack allocation during pattern optimization;
- Node-stack allocation while marking and discarding unused nodes;
- Scanner execution after an internal matching error.

## Changes

### Propagate CheckStack allocation failures

`CheckStack_push()` uses `PyMem_Realloc()` to expand the stack. When the allocation fails, `PyMem_Realloc()` returns `NULL` without setting a Python exception.

The function now calls `PyErr_NoMemory()` before returning `FALSE`.

All `CheckStack_push()` calls in `add_repeat_guards()` are checked. If a push fails:

- The check stack is finalized;
- `add_repeat_guards()` returns `FALSE`;
- `optimise_pattern()` propagates the failure;
- Pattern compilation stops instead of continuing with incomplete repeat-guard information.

### Propagate NodeStack allocation failures

`NodeStack_push()` had the same issue. A failed `PyMem_Realloc()` previously returned `FALSE` without setting an exception, and the return value was ignored by `use_nodes()`.

The failure is now handled throughout the complete call chain:

NodeStack_push() -> use_nodes() -> discard_unused_nodes() -> optimise_pattern() -> compile_to_nodes()

The changes include:

- Calling `PyErr_NoMemory()` when the node stack cannot grow;
- Checking the return value of `NodeStack_push()`;
- Making `use_nodes()` return a failure status;
- Making `discard_unused_nodes()` propagate failures;
- Checking the result of `discard_unused_nodes()` in `optimise_pattern()`;
- Releasing temporary stack memory on failure.

This prevents pattern optimization from continuing after an out-of-memory condition or using incomplete node-usage information.

### Propagate scanner internal errors

When `scanner_search_or_match()` receives an internal negative status from `do_match()`, the previous implementation set the result to `NULL` and returned it without ensuring that a Python exception was set.

The function now sets an appropriate error when no exception is already pending before returning `NULL`.

`scanner_iternext()` also checks whether `scanner_search()` returned `NULL` and propagates that failure directly. This prevents an internal matching error from being mistaken for normal iterator exhaustion.

## Impact

These changes improve the robustness and error semantics of the C extension under memory allocation failures and unexpected internal matching errors.

Without these checks, the affected code could:

- Return `NULL` without a Python exception;
- Produce `SystemError: error return without exception set`;
- Ignore allocation failures;
- Continue compilation with incomplete optimization state;
- Produce incomplete repeat guards or node usage information;
- Stop scanner iteration without reporting the underlying error;
- Make failures difficult to diagnose because the original error context is lost.

The updated code now follows the Python C API error-handling contract. Allocation failures are reported as Python memory errors, internal scanner failures are reported as Python exceptions, and all affected temporary data structures are cleaned up before returning.

Normal pattern compilation, optimization, matching, scanner search, and scanner iteration behavior remain unchanged when all operations succeed.
